### PR TITLE
fix: evaluation by using context for method call

### DIFF
--- a/src/main/java/uk/ac/ed/ph/asciimath/parser/AsciiMathParser.java
+++ b/src/main/java/uk/ac/ed/ph/asciimath/parser/AsciiMathParser.java
@@ -130,7 +130,7 @@ public final class AsciiMathParser {
                     ScriptableObject.putProperty(optionsJS, OPTION_ADD_SOURCE_ANNOTATION, Boolean.TRUE);
                 }
             }
-            final Object result = ScriptableObject.callMethod(parser, "parseAsciiMathInput", new Object[] { asciiMathInput, optionsJS });
+            final Object result = ScriptableObject.callMethod(context, parser, "parseAsciiMathInput", new Object[] { asciiMathInput, optionsJS });
             final Element mathElement = (Element) Context.jsToJava(result, Element.class);
             document.appendChild(mathElement);
             return document;

--- a/src/main/java/uk/ac/ed/ph/asciimath/parser/XmlUtilities.java
+++ b/src/main/java/uk/ac/ed/ph/asciimath/parser/XmlUtilities.java
@@ -41,7 +41,7 @@ import org.w3c.dom.Document;
  *
  * @author David McKain
  */
-final class XmlUtilities {
+public final class XmlUtilities {
 
     /**
      * Creates a (namespace-aware) Xerces DOM {@link DocumentBuilder}, throwing an {@link AsciiMathParserException}


### PR DESCRIPTION
Translating asciimath doesn't work due to usage of top level context.

This should fix it.